### PR TITLE
fix: CardThemeDataからconst修飾を削除

### DIFF
--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -67,11 +67,11 @@ class AppTheme {
           ),
         ),
       ),
-      cardTheme: const CardThemeData(
+      cardTheme: CardThemeData(
         color: Colors.white,
         elevation: 4,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(15)),
+          borderRadius: BorderRadius.circular(15),
         ),
       ),
     );


### PR DESCRIPTION
- Flutter 3.24.0のWeb版でCardThemeDataのconstコンストラクタが存在しない問題を修正
- constを削除し、BorderRadius.all()をBorderRadius.circular()に戻す