### PR TITLE
fix: cardTheme設定を削除

### DIFF
--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -67,13 +67,6 @@ class AppTheme {
           ),
         ),
       ),
-      cardTheme: CardThemeData(
-        color: Colors.white,
-        elevation: 4,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(15),
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
- Flutter 3.24.0のWeb版でCardThemeDataが利用できない問題を修正
- cardTheme設定を完全に削除してビルドエラーを解消