### PR TITLE
fix: peaceiris/actions-gh-pages@v3を@v4にアップグレード

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: flutter build web --release --base-href "/balloon_puzzle/"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/web


### PR DESCRIPTION
Node.js 16のサポート終了により、v3は動作しなくなったため、
v4にアップグレードしてCDデプロイの失敗を修正